### PR TITLE
Add basic Pester test scaffolding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,11 @@ Consistent with security best practices, the app uses a rotating encrypted secre
 
 4. Problems
 If you have any problems, please contact the author.
+
+## Running Tests
+To execute the Pester tests, run:
+
+```powershell
+cd tests
+./run-tests.ps1
+```

--- a/tests/DeviceAndUserLookupFunctions.Tests.ps1
+++ b/tests/DeviceAndUserLookupFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'DeviceAndUserLookupFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'DeviceAndUserLookupFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/DeviceFunctions.Tests.ps1
+++ b/tests/DeviceFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'DeviceFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'DeviceFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/DeviceReportingFunctions.Tests.ps1
+++ b/tests/DeviceReportingFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'DeviceReportingFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'DeviceReportingFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/GraphAPIFunctions.Tests.ps1
+++ b/tests/GraphAPIFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'GraphAPIFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'GraphAPIFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/JsonHelperFunctions.Tests.ps1
+++ b/tests/JsonHelperFunctions.Tests.ps1
@@ -1,0 +1,15 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'JsonHelperFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'JsonHelperFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+    It 'ConvertTo-JsonCompatible returns valid JSON' {
+        $obj = @{Name='Test'; Value=1}
+        $json = ConvertTo-JsonCompatible -InputObject $obj
+        Test-JsonContent -JsonString $json | Should -Be $true
+    }
+}

--- a/tests/MenuFunctions.Tests.ps1
+++ b/tests/MenuFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'MenuFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'MenuFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/MiscFunctions.Tests.ps1
+++ b/tests/MiscFunctions.Tests.ps1
@@ -1,0 +1,14 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'MiscFunctions.ps1'
+$settings = @{ domain = 'example.com' }
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'MiscFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+    It 'NormalizeUserName appends domain' {
+        NormalizeUserName -UserName 'user' -Settings $settings | Should -Be 'user@example.com'
+    }
+}

--- a/tests/ScriptUpdateFunctions.Tests.ps1
+++ b/tests/ScriptUpdateFunctions.Tests.ps1
@@ -1,0 +1,10 @@
+$script:modulePath = Join-Path $PSScriptRoot '..' 'functions' 'ScriptUpdateFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'ScriptUpdateFunctions.ps1' {
+    BeforeAll { . $modulePath }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/SettingsHelperFunctions.Tests.ps1
+++ b/tests/SettingsHelperFunctions.Tests.ps1
@@ -1,0 +1,19 @@
+$script:modulePathJson = Join-Path $PSScriptRoot '..' 'functions' 'JsonHelperFunctions.ps1'
+$modulePath = Join-Path $PSScriptRoot '..' 'functions' 'SettingsHelperFunctions.ps1'
+$expectedFunctions = Select-String -Path $modulePath -Pattern '^[Ff]unction\s+([^(\s]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+Describe 'SettingsHelperFunctions.ps1' {
+    BeforeAll {
+        . $modulePathJson
+        . $modulePath
+    }
+    foreach ($func in $expectedFunctions) {
+        It "defines $func" {
+            Get-Command $func -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+    It 'Format-SettingsJson preserves keys' {
+        $json = '{"a":1,"b":{"c":2}}'
+        $formatted = Format-SettingsJson -JsonString $json
+        $formatted | Should -Match '"c"'
+    }
+}

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -1,0 +1,3 @@
+$module = Join-Path $HOME '.local/share/powershell/Modules/Pester5/Pester.psd1'
+Import-Module $module -ErrorAction Stop
+Invoke-Pester -Path $PSScriptRoot


### PR DESCRIPTION
## Summary
- add initial Pester test files that dot-source scripts in `functions/`
- provide a helper script for running tests
- document how to execute tests in `readme.md`

## Testing
- `pwsh -NoLogo -NoProfile -NonInteractive -File tests/run-tests.ps1` *(fails: Export-ModuleMember only allowed inside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684643f33efc8329888510ba0a1e1362