### PR TITLE
Round total memory calculation to nearest whole number

### DIFF
--- a/functions/deviceFunctions/Get-SystemInformation.ps1
+++ b/functions/deviceFunctions/Get-SystemInformation.ps1
@@ -102,9 +102,9 @@ function Get-SystemInformation()
         Write-Verbose "[$functionName] Retrieving memory information"
 
         $totalMemoryGB = [math]::Round($computerInfo.TotalPhysicalMemory / 1GB, 0)
-        $freeMemoryGB = [math]::Round($osInfo.FreePhysicalMemory / 1MB, 2)
+        $freeMemoryGB = [math]::Round($osInfo.FreePhysicalMemory / 1MB, 0)
 
-        Write-Log -LogFile $logFile -Module $functionName -Message "Total Memory: $totalMemoryGB GB, Free Memory: $freeMemoryGB GB" -LogLevel "Information"
+        Write-Log -LogFile $logFile -Module $logFile -Module $functionName -Message "Total Memory: $totalMemoryGB GB, Free Memory: $freeMemoryGB GB" -LogLevel "Information"
 
         # Gather BIOS Information
         Write-Log -LogFile $logFile -Module $functionName -Message "Retrieving BIOS information" -LogLevel "Verbose"


### PR DESCRIPTION
Adjust the total memory calculation in the Get-SystemInformation function to round to the nearest whole number for improved clarity in memory reporting.